### PR TITLE
Updates to Scala, Scala.js, and GCloud

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -1,9 +1,11 @@
 organization := "$package$"
 name := "$name;format="lower,hyphen"$"
-scalaVersion := "2.12.1"
+scalaVersion := "2.12.7"
 
 enablePlugins(ScalaJSPlugin)
-scalaJSModuleKind := ModuleKind.CommonJSModule
+scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) }
+
+libraryDependencies += "io.scalajs.npm" %%% "express" %%% "0.4.2"
 
 InputKey[Unit]("gcDeploy") := {
   val args = sbt.complete.DefaultParsers.spaceDelimited("gcDeploy <project-id> [<pubsub-topic>]").parsed

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -1,3 +1,5 @@
+import scala.sys.process._
+
 organization := "$package$"
 name := "$name;format="lower,hyphen"$"
 scalaVersion := "2.12.7"
@@ -5,7 +7,7 @@ scalaVersion := "2.12.7"
 enablePlugins(ScalaJSPlugin)
 scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) }
 
-libraryDependencies += "io.scalajs.npm" %%% "express" %%% "0.4.2"
+libraryDependencies += "io.scalajs.npm" %%% "express" % "0.4.2"
 
 InputKey[Unit]("gcDeploy") := {
   val args = sbt.complete.DefaultParsers.spaceDelimited("gcDeploy <project-id> [<pubsub-topic>]").parsed
@@ -20,5 +22,5 @@ InputKey[Unit]("gcDeploy") := {
   val function = gcTarget / "function.js"
   val functionName = "$name;format="camel"$"
   sbt.IO.copyFile((fastOptJS in Compile).value.data, function)
-  s"gcloud beta functions deploy \$functionName --local-path \${gcTarget.getAbsolutePath} --stage-bucket \${name.value} \$trigger --project \$projectId --region us-central1"!
+  s"gcloud functions deploy \$functionName --local-path \${gcTarget.getAbsolutePath} --stage-bucket \${name.value} \$trigger --runtime nodejs8 --project \$projectId --region us-central1"!
 }

--- a/src/main/g8/project/build.properties
+++ b/src/main/g8/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=1.2.8

--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.15")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.26")

--- a/src/main/g8/src/main/scala/$name__Camel$.scala
+++ b/src/main/g8/src/main/scala/$name__Camel$.scala
@@ -2,11 +2,12 @@ package $package$
 
 import scala.scalajs.js
 import scala.scalajs.js.annotation._
+import io.scalajs.npm.express._
 
 object $name;format="Camel"$ {
 
   @JSExportTopLevel("$name;format="camel"$")
-  def function(req: js.Dynamic, res: js.Dynamic) = {
+  def function(req: Request, res: Response) = {
     res.send("ohi")
   }
 


### PR DESCRIPTION
This PR:
- updates Scala
- updates SBT
- updates Scala.js
- updates the `gcloud` command line to sync with changes to that tool
- adds types for the Express API